### PR TITLE
Enable send/receive

### DIFF
--- a/src/zfslib/zfslib.py
+++ b/src/zfslib/zfslib.py
@@ -557,6 +557,18 @@ class Dataset(Snapable):
         super(Dataset, self).__init__(pool, name, parent)
         self.dspath = self.path[len(pool.name)+1:]
 
+    # Take a pipe in and zfs receive it
+    # Blocks until receive is complete
+    # Returns the resulting processess (after it completes)
+    def receive(self, pipe_in):
+        cmd = self.pool.connection.command + ["zfs", "receive", self.path]
+
+        try:
+            p = subprocess.Popen(cmd, stdin=pipe_in)
+            p.wait()
+            return p
+        except Exception as exc:
+            raise exc
 
     # get_diffs() - Gets Diffs in snapshot or between snapshots (if snap_to is specified)
     # snap_from - Left side of diff
@@ -765,6 +777,22 @@ class Snapshot(ZFSItem):
             return (True, snap_path)
         else:
             return (False, snap_path_base)
+
+    # Return a pipe with the contents of the snapshot
+    # Make it an incremental send if incremental_from is passed
+    def send(self, incremental_from=None):
+        if incremental_from and not isinstance(incremental_from, Snapshot):
+            assert 0, "incremental_from must be another snapshot"
+        if incremental_from:
+            cmd = self.pool.connection.command + ["zfs", "send", "-i", incremental_from.path, self.path]
+        else:
+            cmd = self.pool.connection.command + ["zfs", "send", self.path]
+
+        try:
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False)
+            return p.stdout # When the reading starts, the subprocess will also be started
+        except Exception as exc:
+            raise exc
 
 
     def __str__(self):


### PR DESCRIPTION
This worked for me.

On the receiving side I had to:

```
sudo zfs allow $(whoami) receive,create,mount tank
```

On the sending side I had to 

```
sudo zfs allow -u $(whoami) send,hold tank
```

then this worked from an un-elevated user:

```
local_dataset.receive(remote_newest_snapshot.send(remote_common_snapshot))
```
where the two snapshots were from a zfslib.Connection() to one server and the dataset was a zfslib.Connection to another.

When there were errors, I saw them and the program I was running exited. Had I chosen to trap more exceptions in my own code, I would have been able to decide not to exit.